### PR TITLE
Always use explicit option when scheduling jobs

### DIFF
--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -213,12 +213,6 @@ class Schedule(Interface):
             commit message.""",
             constraints=EnsureChoice(None, "inputs", "outputs", "both")),
         assume_ready=assume_ready_opt,
-        explicit=Parameter(
-            args=("--explicit",),
-            action="store_true",
-            doc="""Consider the specification of inputs and outputs to be
-            explicit. Don't warn if the repository is dirty, and only save
-            modifications to the listed outputs."""),
         message=save_message_opt,
         sidecar=Parameter(
             args=('--sidecar',),
@@ -262,7 +256,6 @@ class Schedule(Interface):
             outputs=None,
             expand=None,
             assume_ready=None,
-            explicit=False,
             message=None,
             dry_run=None,
             jobs=None):
@@ -270,7 +263,6 @@ class Schedule(Interface):
                              inputs=inputs, outputs=outputs,
                              expand=expand,
                              assume_ready=assume_ready,
-                             explicit=explicit,
                              message=message,
                              dry_run=dry_run,
                              jobs=jobs):
@@ -408,8 +400,9 @@ def _create_record(run_info, sidecar_flag, ds):
 
 
 def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
-                assume_ready=None, explicit=False, message=None, sidecar=None,
+                assume_ready=None, message=None, sidecar=None,
                 dry_run=False, jobs=None,
+                explicit=True,
                 extra_info=None,
                 rerun_info=None,
                 extra_inputs=None,


### PR DESCRIPTION
The point of `schedule` (and `reschedule`) is that it sets up files to be committed at a later stage, once the jobs have run and `datalad finish` is executed. So the default behaviour should allow for commits on a dirty repo (unlike `datalad run`).

This sets `explicit` to be always `True` (and in the current state does not give the user an optional parameter to change that). Some mentions of `explicit` remain in case we decide to change that in the future.

Closes issue #6 