### PR TITLE
Add incomplete flag

### DIFF
--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -64,7 +64,7 @@ from datalad.utils import (
     quote_cmdlinearg,
 )
 
-from .common import check_finish_exists, get_schedule_info
+from .common import check_finish_exists, get_schedule_info, extract_incomplete_jobs
 
 from datalad.core.local.run import _create_record, get_command_pwds
 
@@ -364,6 +364,10 @@ def finish_cmd(
     # delete the slurm_job_id file
     # slurm_submission_file = f"slurm-job-submission-{slurm_job_id}"
     # os.remove(slurm_submission_file)
+
+    # get the number of incomplete jobs and subtract one
+    incomplete_job_number = extract_incomplete_jobs(ds)
+    run_info["incomplete_job_number"] = incomplete_job_number - 1
 
     # expand the wildcards
     # TODO do this in a better way with GlobbedPaths

--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -85,7 +85,7 @@ from datalad.core.local.run import (
     _get_substitutions,
 )
 
-from .common import get_schedule_info, check_finish_exists
+from .common import get_schedule_info, check_finish_exists, extract_incomplete_jobs
 
 lgr = logging.getLogger("datalad.slurm.schedule")
 
@@ -672,6 +672,10 @@ def run_command(
             ),
         )
         return
+
+    # extract the incomplete job number
+    incomplete_job_number = extract_incomplete_jobs(ds)
+    run_info["incomplete_job_number"] = incomplete_job_number + 1
 
     # now check history of outputs in un-finished slurm commands
     if check_outputs:


### PR DESCRIPTION
This a fix for issue #15.

In order to speed up the `datalad finish` command, we no longer look through the whole git history to find scheduled commits without a corresponding finish. Instead, we record a parameter "incomplete_job_number" in the git log entry. At any point in the git history when all scheduled commands have also been finished, this will equal 0. `datalad finish` now only searches as far back as the last entry where this number is equal to 0.