### PR TITLE
Ensure expand option captures slurm outputs

### DIFF
--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -715,6 +715,9 @@ def run_command(
         globbed["outputs"].expand(refresh=True)
         if expand in ["outputs", "both"]:
             run_info["outputs"] = globbed["outputs"].paths
+            # add the slurm outputs and environment files
+            # these are not captured in the initial globbing
+            run_info["outputs"].extend(slurm_outputs)
 
     # create the run record, either as a string, or written to a file
     # depending on the config/request


### PR DESCRIPTION
Fixes issue #17. As `expand` options re-globs outputs, it was not including the slurm outputs (which are added after the submit script is submitted). This adds the slurm outputs after.