### PR TITLE
Print expanded output paths for `datalad finish`

### DIFF
--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -403,12 +403,13 @@ def finish_cmd(
 
     # expand the wildcards
     # TODO do this in a better way with GlobbedPaths
-    globbed_outputs = []
-    for k in outputs_to_save:
-        globbed_outputs.extend(glob.glob(k))
+    globbed_outputs = GlobbedPaths(outputs_to_save, expand=True).paths
     # TODO should the globbed outputs only be the slurm outputs in this case?
     if job_status in ["CANCELLED", "FAILED"]:
         globbed_outputs.extend(run_info["slurm_run_outputs"])
+
+    # update the run info with the new outputs
+    run_info["outputs"] = globbed_outputs
 
     # TODO: this is not saving model files (outputs from first job) for some reason
     # rel_pwd = rerun_info.get('pwd') if rerun_info else None


### PR DESCRIPTION
`datalad finish` now prints expanded paths (from wildcards) in the git commit message, rather than repeating the unexpanded paths from `datalad schedule`.