### PR TITLE
Allow wildcards for reschedule

### DIFF
--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -564,7 +564,7 @@ def run_command(
             )
             return
     
-    if not allow_wildcard_outputs and outputs:
+    if not rerun_info and not allow_wildcard_outputs and outputs:
         wildcard_list = ["*", "?", "[", "]", "!", "^", "{", "}"]
         if any(char in output for char in wildcard_list for output in outputs):
             yield get_status_dict(


### PR DESCRIPTION
Switches off the wildcard checking for rescheduled jobs (since they just inherit the outputs from schedule). Fix for issue #39 