### PR TITLE
Cleanup code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/datalad_slurm/__init__.py
+++ b/datalad_slurm/__init__.py
@@ -1,9 +1,10 @@
 """DataLad demo extension"""
 
-__docformat__ = 'restructuredtext'
+__docformat__ = "restructuredtext"
 
 import logging
-lgr = logging.getLogger('datalad.slurm')
+
+lgr = logging.getLogger("datalad.slurm")
 
 # Defines a datalad command suite.
 # This variable must be bound as a setuptools entrypoint
@@ -14,36 +15,37 @@ command_suite = (
     [
         (
             # importable module that contains the schedule command implementation
-            'datalad_slurm.schedule',
+            "datalad_slurm.schedule",
             # name of the command class implementation in above module
-            'Schedule',
+            "Schedule",
             # optional name of the command in the cmdline API
-            'schedule',
+            "schedule",
             # optional name of the command in the Python API
-            'schedule'
+            "schedule",
         ),
         (
             # importable module that contains the schedule command implementation
-            'datalad_slurm.finish',
+            "datalad_slurm.finish",
             # name of the command class implementation in above module
-            'Finish',
+            "Finish",
             # optional name of the command in the cmdline API
-            'finish',
+            "finish",
             # optional name of the command in the Python API
-            'finish'
+            "finish",
         ),
         (
             # importable module that contains the schedule command implementation
-            'datalad_slurm.reschedule',
+            "datalad_slurm.reschedule",
             # name of the command class implementation in above module
-            'Reschedule',
+            "Reschedule",
             # optional name of the command in the cmdline API
-            'reschedule',
+            "reschedule",
             # optional name of the command in the Python API
-            'reschedule'
-        ),                
-    ]
+            "reschedule",
+        ),
+    ],
 )
 
 from . import _version
-__version__ = _version.get_versions()['version']
+
+__version__ = _version.get_versions()["version"]

--- a/datalad_slurm/_version.py
+++ b/datalad_slurm/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -60,17 +59,18 @@ HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     process = None
@@ -86,10 +86,14 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([command] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            process = subprocess.Popen([command] + args, cwd=cwd, env=env,
-                                       stdout=subprocess.PIPE,
-                                       stderr=(subprocess.PIPE if hide_stderr
-                                               else None), **popen_kwargs)
+            process = subprocess.Popen(
+                [command] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+                **popen_kwargs,
+            )
             break
         except OSError:
             e = sys.exc_info()[1]
@@ -124,15 +128,21 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for _ in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         rootdirs.append(root)
         root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -191,7 +201,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
+    tags = {r[len(TAG) :] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -200,7 +210,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = {r for r in refs if re.search(r'\d', r)}
+        tags = {r for r in refs if re.search(r"\d", r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -208,24 +218,31 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             # Filter out refs that exactly match prefix or that don't start
             # with a number once the prefix is stripped (mostly a concern
             # when prefix is '')
-            if not re.match(r'\d', r):
+            if not re.match(r"\d", r):
                 continue
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -247,8 +264,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     env.pop("GIT_DIR", None)
     runner = functools.partial(runner, env=env)
 
-    _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                   hide_stderr=True)
+    _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -256,10 +272,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = runner(GITS, [
-        "describe", "--tags", "--dirty", "--always", "--long",
-        "--match", f"{tag_prefix}[[:digit:]]*"
-        ], cwd=root)
+    describe_out, rc = runner(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            f"{tag_prefix}[[:digit:]]*",
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -274,8 +299,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None
 
-    branch_name, rc = runner(GITS, ["rev-parse", "--abbrev-ref", "HEAD"],
-                             cwd=root)
+    branch_name, rc = runner(GITS, ["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
     # --abbrev-ref was added in git-1.6.3
     if rc != 0 or branch_name is None:
         raise NotThisMethod("'git rev-parse --abbrev-ref' returned error")
@@ -315,17 +339,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparsable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -334,10 +357,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -386,8 +411,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -416,8 +440,7 @@ def render_pep440_branch(pieces):
         rendered = "0"
         if pieces["branch"] != "master":
             rendered += ".dev0"
-        rendered += "+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered += "+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -578,11 +601,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -606,9 +631,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -622,8 +651,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -632,13 +660,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for _ in cfg.versionfile_source.split('/'):
+        for _ in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -652,6 +683,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/datalad_slurm/common.py
+++ b/datalad_slurm/common.py
@@ -25,8 +25,6 @@ def get_finish_info(dset, message):
     ------
     A ValueError if the information in `message` is invalid.
     """
-    # TODO fix the cmd_regex
-
     cmdrun_regex = (
         r"\[DATALAD SLURM RUN\] (.*)=== Do not change lines below "
         r"===\n(.*)\n\^\^\^ Do not change lines above \^\^\^"
@@ -60,21 +58,6 @@ def get_finish_info(dset, message):
     if "cmd" not in runinfo:
         raise ValueError("Looks like a finish commit but does not have a command")
     return rec_msg.rstrip(), runinfo
-
-
-def check_finish_exists(dset, revision, rev_branch, allow_reschedule=True):
-    """Check if a job is open or already finished."""
-    # connect to the database
-    con, cur = connect_to_database(dset)
-    if con is None or cur is None:
-        return None, None
-
-    # check the open jobs for the commit
-    cur.execute("SELECT 1 FROM open_jobs WHERE commit_id LIKE ?", (revision + "%",))
-    finish_exists = cur.fetchone() is None
-    con.close()
-
-    return finish_exists, True
 
 
 def connect_to_database(dset, row_factory=False):

--- a/datalad_slurm/common.py
+++ b/datalad_slurm/common.py
@@ -9,28 +9,28 @@ from datalad.support.json_py import load_stream
 
 
 def get_finish_info(dset, message):
-   """
-   Extract information about a finished slurm job from its commit message.
+    """
+    Extract information about a finished slurm job from its commit message.
 
-   Parameters
-   ----------
-   dset : Dataset
-       Dataset object containing the run record
-   message : str
-       A commit message
+    Parameters
+    ----------
+     dset : Dataset
+         Dataset object containing the run record
+     message : str
+         A commit message
 
-   Returns
-   -------
-   tuple
-       (str or None, dict or None)
-       - str: Command message if found, None otherwise
-       - dict: Finish information if found, None otherwise
+    Returns
+    -------
+    tuple
+           (str or None, dict or None)
+        - str: Command message if found, None otherwise
+        - dict: Finish information if found, None otherwise
 
-   Raises
-   ------
-   ValueError
-       If message contains invalid JSON or missing command information
-   """
+    Raises
+    ------
+    ValueError
+           If message contains invalid JSON or missing command information
+    """
     cmdrun_regex = (
         r"\[DATALAD SLURM RUN\] (.*)=== Do not change lines below "
         r"===\n(.*)\n\^\^\^ Do not change lines above \^\^\^"
@@ -67,26 +67,26 @@ def get_finish_info(dset, message):
 
 
 def connect_to_database(dset, row_factory=False):
-   """
-   Connect to sqlite3 database and return the connection and cursor.
+    """
+    Connect to sqlite3 database and return the connection and cursor.
 
-   Parameters
-   ----------
-   dset : Dataset
-       Dataset object with repo and path information
-   row_factory : bool, optional
-       If True, return single-column results as scalars instead of tuples, default False
+    Parameters
+    ----------
+    dset : Dataset
+           Dataset object with repo and path information
+    row_factory : bool, optional
+           If True, return single-column results as scalars instead of tuples, default False
 
-   Returns
-   -------
-   tuple
-       (sqlite3.Connection or None, sqlite3.Cursor or None)
-       Connection and cursor objects if successful, (None, None) if connection fails
+    Returns
+    -------
+    tuple
+        (sqlite3.Connection or None, sqlite3.Cursor or None)
+        Connection and cursor objects if successful, (None, None) if connection fails
 
-   Notes
-   -----
-   Database path is constructed from dataset ID and branch in .git directory
-   """
+    Notes
+    -----
+    Database path is constructed from dataset ID and branch in .git directory
+    """
     # define the database path from the dataset and branch
     ds_repo = dset.repo
     branch = ds_repo.get_corresponding_branch() or ds_repo.get_active_branch() or "HEAD"

--- a/datalad_slurm/common.py
+++ b/datalad_slurm/common.py
@@ -9,22 +9,28 @@ from datalad.support.json_py import load_stream
 
 
 def get_finish_info(dset, message):
-    """Extract finish information from `message`
+   """
+   Extract information about a finished slurm job from its commit message.
 
-    Parameters
-    ----------
-    message : str
-        A commit message.
+   Parameters
+   ----------
+   dset : Dataset
+       Dataset object containing the run record
+   message : str
+       A commit message
 
-    Returns
-    -------
-    A tuple with the command's message and a dict with finish information. Both
-    these values are None if `message` doesn't have a finish command.
+   Returns
+   -------
+   tuple
+       (str or None, dict or None)
+       - str: Command message if found, None otherwise
+       - dict: Finish information if found, None otherwise
 
-    Raises
-    ------
-    A ValueError if the information in `message` is invalid.
-    """
+   Raises
+   ------
+   ValueError
+       If message contains invalid JSON or missing command information
+   """
     cmdrun_regex = (
         r"\[DATALAD SLURM RUN\] (.*)=== Do not change lines below "
         r"===\n(.*)\n\^\^\^ Do not change lines above \^\^\^"
@@ -61,7 +67,26 @@ def get_finish_info(dset, message):
 
 
 def connect_to_database(dset, row_factory=False):
-    """Connect to sqlite3 database and return the connection and cursor."""
+   """
+   Connect to sqlite3 database and return the connection and cursor.
+
+   Parameters
+   ----------
+   dset : Dataset
+       Dataset object with repo and path information
+   row_factory : bool, optional
+       If True, return single-column results as scalars instead of tuples, default False
+
+   Returns
+   -------
+   tuple
+       (sqlite3.Connection or None, sqlite3.Cursor or None)
+       Connection and cursor objects if successful, (None, None) if connection fails
+
+   Notes
+   -----
+   Database path is constructed from dataset ID and branch in .git directory
+   """
     # define the database path from the dataset and branch
     ds_repo = dset.repo
     branch = ds_repo.get_corresponding_branch() or ds_repo.get_active_branch() or "HEAD"

--- a/datalad_slurm/common.py
+++ b/datalad_slurm/common.py
@@ -1,66 +1,11 @@
 __docformat__ = "restructuredtext"
 
 import json
-import logging
 import os.path as op
 import re
-import sys
-from copy import copy
-from functools import partial
-from itertools import dropwhile
 import sqlite3
 
-from datalad.consts import PRE_INIT_COMMIT_SHA
-from datalad.core.local.run import (
-    _format_cmd_shorty,
-    assume_ready_opt,
-    format_command,
-)
-from datalad.distribution.dataset import (
-    EnsureDataset,
-    datasetmethod,
-    require_dataset,
-)
-from datalad.interface.base import (
-    Interface,
-    build_doc,
-    eval_results,
-)
-from datalad.interface.common_opts import jobs_opt
-from datalad.interface.results import get_status_dict
-from datalad.support.constraints import (
-    EnsureNone,
-    EnsureStr,
-)
-from datalad.support.exceptions import CapturedException
 from datalad.support.json_py import load_stream
-from datalad.support.param import Parameter
-
-from datalad.utils import (
-    SequenceFormatter,
-    chpwd,
-    ensure_list,
-    ensure_unicode,
-    get_dataset_root,
-    getpwd,
-    join_cmdline,
-    quote_cmdlinearg,
-)
-
-from datalad.core.local.run import (
-    _format_cmd_shorty,
-    get_command_pwds,
-    _display_basic,
-    prepare_inputs,
-    _prep_worktree,
-    format_command,
-    normalize_command,
-    _create_record,
-    _format_iospecs,
-    _get_substitutions,
-)
-
-from datalad.support.globbedpaths import GlobbedPaths
 
 
 def get_finish_info(dset, message):

--- a/datalad_slurm/common.py
+++ b/datalad_slurm/common.py
@@ -131,6 +131,7 @@ def check_finish_exists(dset, revision, rev_branch, allow_reschedule=True):
 
     return finish_exists, True
 
+
 def connect_to_database(dset, row_factory=False):
     """Connect to sqlite3 database and return the connection and cursor."""
     # define the database path from the dataset and branch
@@ -138,7 +139,7 @@ def connect_to_database(dset, row_factory=False):
     branch = ds_repo.get_corresponding_branch() or ds_repo.get_active_branch() or "HEAD"
     db_name = f"{dset.id}_{branch}.db"
     db_path = dset.pathobj / ".git" / db_name
-    
+
     # try to connect to the database
     try:
         con = sqlite3.connect(db_path)
@@ -147,6 +148,5 @@ def connect_to_database(dset, row_factory=False):
         cur = con.cursor()
     except sqlite3.Error:
         return None, None
-    
+
     return con, cur
-            

--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -256,8 +256,10 @@ def finish_cmd(
         status_summary = ", ".join(
             f"{job_id}: {status}" for job_id, status in job_states.items()
         )
-        message = (f"Slurm job(s) for job {slurm_job_id} are not complete."
-                   f"Statuses: {status_summary}")
+        message = (
+            f"Slurm job(s) for job {slurm_job_id} are not complete."
+            f"Statuses: {status_summary}"
+        )
         if any(status in ["PENDING", "RUNNING"] for status in job_states.values()):
             yield get_status_dict("finish", status="error", message=message)
             return
@@ -311,7 +313,8 @@ def finish_cmd(
     record, record_path = _create_record(run_info, False, ds)
 
     msg = msg.format(
-        message_entry, '"{}"'.format(record) if record_path else record,
+        message_entry,
+        '"{}"'.format(record) if record_path else record,
     )
 
     # remove the job

--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -269,7 +269,7 @@ def finish_cmd(
     # should throw an error if user doesn't specify outputs or directory
     if not outputs_to_save:
         err_msg = "You must specify which outputs to save from this slurm run."
-        yield get_status_dict("finish", status="error", message=err_msg)
+        yield get_status_dict("finish", status="impossible", message=err_msg)
         return
 
     slurm_job_id = slurm_run_info["slurm_job_id"]
@@ -291,11 +291,11 @@ def finish_cmd(
             f"Statuses: {status_summary}"
         )
         if any(status in ["PENDING", "RUNNING"] for status in job_states.values()):
-            yield get_status_dict("finish", status="error", message=message)
+            yield get_status_dict("finish", status="impossible", message=message)
             return
         else:
             if not close_failed_jobs:
-                yield get_status_dict("finish", status="error", message=message)
+                yield get_status_dict("finish", status="impossible", message=message)
                 return
             else:
                 # remove the job

--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -202,7 +202,7 @@ def finish_cmd(
 
     if not explicit:
         yield get_status_dict(
-            "run",
+            "finish",
             ds=ds,
             status="impossible",
             message=(
@@ -214,7 +214,7 @@ def finish_cmd(
 
     if not ds_repo.get_hexsha():
         yield get_status_dict(
-            "run",
+            "finish",
             ds=ds,
             status="impossible",
             message="cannot rerun command, nothing recorded",
@@ -239,7 +239,7 @@ def finish_cmd(
     # should throw an error if user doesn't specify outputs or directory
     if not outputs_to_save:
         err_msg = "You must specify which outputs to save from this slurm run."
-        yield get_status_dict("run", status="error", message=err_msg)
+        yield get_status_dict("finish", status="error", message=err_msg)
         return
 
     slurm_job_id = run_info["slurm_job_id"]

--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -257,7 +257,7 @@ def finish_cmd(
             f"{job_id}: {status}" for job_id, status in job_states.items()
         )
         message = (f"Slurm job(s) for job {slurm_job_id} are not complete."
-                   "Statuses: {status_summary}")
+                   f"Statuses: {status_summary}")
         if any(status in ["PENDING", "RUNNING"] for status in job_states.values()):
             yield get_status_dict("finish", status="error", message=message)
             return

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -45,7 +45,7 @@ from datalad.core.local.run import (
 )
 
 # from .schedule import _execute_slurm_command
-from .schedule import run_command
+from .schedule import schedule_cmd
 
 from .common import get_finish_info
 
@@ -462,7 +462,7 @@ def _rerun(dset, results, assume_ready=None, explicit=True, jobs=None):
 
             message = res["rerun_message"] or res["run_message"]
             message = check_job_pattern(message)
-            for r in run_command(
+            for r in schedule_cmd(
                 run_info["cmd"],
                 dataset=dset,
                 inputs=run_info.get("inputs", []),

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -280,7 +280,9 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
         results = _revrange_as_results(dset, revrange)
     except ValueError as exc:
         ce = CapturedException(exc)
-        yield get_status_dict("reschedule", status="error", message=str(ce), exception=ce)
+        yield get_status_dict(
+            "reschedule", status="error", message=str(ce), exception=ce
+        )
         return
 
     ds_repo = dset.repo

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -190,7 +190,7 @@ class Reschedule(Interface):
 
         if not ds_repo.get_hexsha():
             yield get_status_dict(
-                "run",
+                "reschedule",
                 ds=ds,
                 status="impossible",
                 message="cannot reschedule command, nothing recorded",
@@ -247,7 +247,7 @@ def _revrange_as_results(dset, revrange):
         # custom `rev-list --parents ...` call to avoid this.)
         fields = rev_line.strip().split(" ")
         rev, parents = fields[0], fields[1:]
-        res = get_status_dict("run", ds=dset, commit=rev, parents=parents)
+        res = get_status_dict("reschedule", ds=dset, commit=rev, parents=parents)
         full_msg = ds_repo.format_commit("%B", rev)
         try:
             msg, info = get_finish_info(dset, full_msg)
@@ -280,7 +280,7 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
         results = _revrange_as_results(dset, revrange)
     except ValueError as exc:
         ce = CapturedException(exc)
-        yield get_status_dict("run", status="error", message=str(ce), exception=ce)
+        yield get_status_dict("reschedule", status="error", message=str(ce), exception=ce)
         return
 
     ds_repo = dset.repo
@@ -291,7 +291,7 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
     results = list(dropwhile(lambda r: "run_info" not in r, results))
     if not results:
         yield get_status_dict(
-            "run",
+            "reschedule",
             status="impossible",
             ds=dset,
             message=("No schedule commits found in range %s", revrange),
@@ -583,7 +583,7 @@ def _get_script_handler(script, since, revision):
             yield None
         else:
             yield get_status_dict(
-                "run",
+                "reschedule",
                 ds=dset,
                 status="ok",
                 path=script,

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
-# ex: set sts=4 ts=4 sw=4 et:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
 #   See COPYING file distributed along with the datalad package for the
@@ -11,7 +9,6 @@
 __docformat__ = "restructuredtext"
 
 
-import json
 import logging
 import os.path as op
 import re
@@ -21,11 +18,7 @@ from functools import partial
 from itertools import dropwhile
 
 from datalad.consts import PRE_INIT_COMMIT_SHA
-from datalad.core.local.run import (
-    _format_cmd_shorty,
-    assume_ready_opt,
-    format_command,
-)
+
 from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
@@ -43,39 +36,18 @@ from datalad.support.constraints import (
     EnsureStr,
 )
 from datalad.support.exceptions import CapturedException
-from datalad.support.json_py import load_stream
 from datalad.support.param import Parameter
-
-from datalad.utils import (
-    SequenceFormatter,
-    chpwd,
-    ensure_list,
-    ensure_unicode,
-    get_dataset_root,
-    getpwd,
-    join_cmdline,
-    quote_cmdlinearg,
-)
 
 from datalad.core.local.run import (
     _format_cmd_shorty,
-    get_command_pwds,
-    _display_basic,
-    prepare_inputs,
-    _prep_worktree,
     format_command,
-    normalize_command,
-    _create_record,
-    _format_iospecs,
-    _get_substitutions,
+    assume_ready_opt,
 )
-
-from datalad.support.globbedpaths import GlobbedPaths
 
 # from .schedule import _execute_slurm_command
 from .schedule import run_command
 
-from .common import get_finish_info, check_finish_exists
+from .common import get_finish_info
 
 lgr = logging.getLogger("datalad.local.reschedule")
 
@@ -325,8 +297,6 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
             message=("No schedule commits found in range %s", revrange),
         )
         return
-
-    start_point = "HEAD"
 
     def skip_or_pick(hexsha, result, msg):
         result["rerun_action"] = "skip-or-pick"

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -311,7 +311,6 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
         yield get_status_dict("run", status="error", message=str(ce), exception=ce)
         return
 
-
     ds_repo = dset.repo
     # Drop any leading commits that don't have a run command. These would be
     # skipped anyways.
@@ -668,6 +667,7 @@ def new_or_modified(diff_results):
         ]:
             r.pop("status", None)
             yield r
+
 
 def check_job_pattern(text):
     pattern = r"Submitted batch job \d+: Pending"

--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -242,7 +242,7 @@ class Schedule(Interface):
         dry_run=None,
         jobs=None,
     ):
-        for r in run_command(
+        for r in schedule_cmd(
             cmd,
             dataset=dataset,
             inputs=inputs,
@@ -353,7 +353,7 @@ def _execute_slurm_command(command, pwd):
     return cmd_exitcode or 0, exc, job_id
 
 
-def run_command(
+def schedule_cmd(
     cmd,
     dataset=None,
     inputs=None,

--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -472,7 +472,7 @@ def schedule_cmd(
         # MIH: is_dirty() is gone, but status() can do all of the above!
         if not explicit and ds.repo.dirty:
             yield get_status_dict(
-                "run",
+                "schedule",
                 ds=ds,
                 status="impossible",
                 message=(
@@ -485,7 +485,7 @@ def schedule_cmd(
     wildcard_list = ["*", "?", "[", "]", "!", "^", "{", "}"]
     if any(char in output for char in wildcard_list for output in outputs):
         yield get_status_dict(
-            "run",
+            "schedule",
             ds=ds,
             status="impossible",
             message=(
@@ -555,7 +555,7 @@ def schedule_cmd(
         }
     except KeyError as exc:
         yield get_status_dict(
-            "run",
+            "schedule",
             ds=ds,
             status="impossible",
             message=(
@@ -598,7 +598,7 @@ def schedule_cmd(
         cmd_expanded = format_command(ds, cmd, **cmd_fmt_kwargs)
     except KeyError as exc:
         yield get_status_dict(
-            "run",
+            "schedule",
             ds=ds,
             status="impossible",
             message=("command has an unrecognized placeholder: %s", exc),
@@ -637,7 +637,7 @@ def schedule_cmd(
 
     if dry_run:
         yield get_status_dict(
-            "run [dry-run]",
+            "schedule [dry-run]",
             ds=ds,
             status="ok",
             message="Dry run",
@@ -708,7 +708,7 @@ def schedule_cmd(
         return
 
     run_result = get_status_dict(
-        "run",
+        "schedule",
         ds=ds,
         status=status,
         # use the abbrev. command as the message to give immediate clarity what

--- a/tests/test_03_output_to_same_dir.sh
+++ b/tests/test_03_output_to_same_dir.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-nset -e # abort on errors
+set -e # abort on errors
 
 # Test datalad 'schedule' and 'finish' functionality
 #   - 'datalad schedule' several jobs with the same output dir but different output file names


### PR DESCRIPTION
The code is tidied up a bit, in particular:

- [x] Unused imports are removed
- [x] `black` is used to format the code
- [x] Possible errors caught by `flake8` are fixed
- [x] `run_command` --> `schedule_cmd`
- [x] numpy style docstrings added
- [x] "run_info" converted to "slurm_run_info" (or similar) to avoid confusion with regular `datalad run` commands