### PR TITLE
Update licence and contributors

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,23 +1,24 @@
 {
   "creators": [
     {
-      "affiliation": "Edit me!",
-      "name": "Edit me!",
-      "orcid": "Edit me!"
+      "affiliation": "Center for Advanced Systems Understanding, Helmholtz-Zentrum Dresden-Rossendorf",
+      "name": "Andreas Knüpfer",
+      "orcid": "0000-0003-3591-397X"
     },
     {
-      "affiliation": "Edit me!",
-      "name": "Edit me!",
-      "orcid": "Edit me!"
+      "affiliation": "Center for Advanced Systems Understanding, Helmholtz-Zentrum Dresden-Rossendorf",
+      "name": "Timothy Callow",
+      "orcid": "0000-0002-4878-3521"
     }
   ],
   "keywords": [
     "data management",
     "data distribution",
     "execution provenance tracking",
-    "version control"
+    "version control",
+    "HPC"
   ],
   "access_right": "open",
-  "license": "Edit me!",
+  "license": "The MIT License",
   "upload_type": "software"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,9 @@
-## Releasing with GitHub Actions and pull requests
+## Contributing to datalad-slurm
 
-New releases of this project are created via a GitHub Actions workflow using
-[datalad/release-action](https://github.com/datalad/release-action), which was
-inspired by [`auto`](https://github.com/intuit/auto).  Whenever a pull request
-is merged into `main` that has the "`release`" label, the workflow updates the
-changelog based on the pull requests since the previous release, commits the
-results, tags the new commit with the next version number, creates a GitHub
-release for the tag, builds an sdist & wheel for the project, and uploads the
-sdist & wheel to PyPI.
+We welcome your contributions, please adhere to the following guidelines when contributing to the code:
+* In general, contributors should develop on branches based off of `develop` and merge requests should be to `develop`
+* Please choose a descriptive branch name
+* Merges from `develop` to `master` will be done after prior consultation of the core development team
+* Merges from `develop` to `master` are only done for code releases. This way we always have a clean `master` that reflects the current release
+* Code should be formatted using [black](https://pypi.org/project/black/) style
 
-### CHANGELOG entries and labelling pull requests
-
-This project uses [scriv](https://github.com/nedbat/scriv/) to maintain the
-[CHANGELOG.md](./CHANGELOG.md) file.  Adding the label `CHANGELOG-missing` to a
-PR triggers a workflow to add a new `scriv` changelog fragment under
-`changelog.d/` using the PR title as the content.  That produced changelog
-snippet can subsequently be tuned to improve the prospective CHANGELOG entry.
-The changelog section that the fragment is added under depends on the `semver-`
-label added to the PR:
-
-- `semver-minor` — for changes corresponding to an increase in the minor
-  version component
-- `semver-patch` — for changes corresponding to an increase in the patch/micro
-  version component
-- `semver-internal` — for changes only affecting the internal API
-- `semver-documentation` — for changes only affecting the documentation
-- `semver-tests` — for changes to tests
-- `semver-dependencies` — for updates to dependency versions
-- `semver-performance` — for performance improvements

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 The following people have contributed to this project:
 
-Michael Hanke
+Timothy Callow 
+Andreas Knüpfer

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ documentation is covered by the MIT license.
 
   The MIT License
 
-  Copyright (c) 2024-     Timothy Callow and Andreas Knüpfer
+  Copyright (c) 2024-     Andreas Knüpfer and Timothy Callow
                           Center for Advanced Systems Understanding
                           Helmholtz-Zentrum Dresden-Rossendorf
 

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,10 @@ documentation is covered by the MIT license.
 
   The MIT License
 
-  Copyright (c) 2024-     DataLad-slurm Team
+  Copyright (c) 2024-     Timothy Callow and Andreas Knüpfer
+                          Center for Advanced Systems Understanding
+                          Helmholtz-Zentrum Dresden-Rossendorf
+
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
 # Main Copyright/License
 
-DataLad, including all examples, code snippets and attached
+DataLad-slurm, including all examples, code snippets and attached
 documentation is covered by the MIT license.
 
   The MIT License
 
-  Copyright (c) 2018-     DataLad Team
+  Copyright (c) 2024-     DataLad-slurm Team
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
-url = https://github.com/datalad/datalad-extension-template
-author = The DataLad Team and Contributors
-author_email = team@datalad.org
-description = demo DataLad extension package
+url = https://github.com/timcallow/datalad-slurm
+author = Andreas Knüpfer and Timothy Callow 
+author_email = a.knuepfer@hzdr.de‎
+description = DataLad extension for HPC (slurm) systems
 long_description = file:README.md
 long_description_content_type = text/markdown; charset=UTF-8
 license = MIT


### PR DESCRIPTION
Gives copyright to the "DataLad-slurm" team.

@knuedd I don't know what you want the naming convention of the package to be, so feel free to change that. I just named the "DataLad-slurm" team as the copyright holders, of course that could also be changed...