### PR TITLE
Change datalad <x> commands to datalad slurm-<x> to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,48 +26,48 @@ Then, clone this repository and install the extension with:
 
 To **schedule** a slurm script:
 
-    datalad schedule --output=<output_files_or_dir> <slurm_submission_command>
+    datalad slurm-schedule --output=<output_files_or_dir> <slurm_submission_command>
 
 where `<output_files_or_dir>` are the expected outputs from the job, and `<slurm_submission_command>` is for example `sbatch submit_script`. Further optional command line arguments can be found in the documentation.
 
-Multiple jobs (including array jobs) can be scheduled sequentially. They are tracked in an SQLite database. Note that any open jobs must not have conflicting outputs with previously scheduled jobs. This is so that the outputs of each slurm run can be tracked to their correct 
+Multiple jobs (including array jobs) can be scheduled sequentially. They are tracked in an SQLite database. Note that any open jobs must not have conflicting outputs with previously scheduled jobs. This is so that the outputs of each slurm run can be tracked to the slurm job which generated them.
 
 To **finish** (i.e. post-process) these jobs (once they are complete), simply run:
 
-    datalad finish
+    datalad slurm-finish
 
 Alternatively, to finish a particular scheduled job, run:
 
-    datalad finish <slurm_job_id>
+    datalad slurm-finish <slurm_job_id>
 
 This will create a `[DATALAD SLURM RUN]` entry in the git log, analagous to a `datalad run` command.
 
 `datalad-slurm` will flag an error for any jobs which could not be post-processed, either because they are still running, or the job failed. These are not automatically cleared from the SQLite database. The output files should first be removed or manually added in git, before running
 
-    datalad finish --close-failed-jobs
+    datalad slurm-finish --close-failed-jobs
 
 To clear the SQLite database. To inspect the current status of all open jobs (without saving anything in git), run:
 
-    datalad finish --list-open-jobs
+    datalad slurm-finish --list-open-jobs
 
 To **reschedule** a previously scheduled job:
 
-    datalad reschedule <schedule_commit_hash>
+    datalad slurm-reschedule <schedule_commit_hash>
 
-where `<schedule_commit_hash>` is the commit hash of the previously scheduled job. There must also be a corresponding `datalad finish` command to the original `datalad schedule`, otherwise `datalad reschedule` will throw an error.
+where `<schedule_commit_hash>` is the commit hash of the previously scheduled job. There must also be a corresponding `datalad slurm-finish` command to the original `datalad slurm-schedule`, otherwise `datalad slurm-reschedule` will throw an error.
 
-In the lingo of the original DataLad package, the combination of `datalad schedule + datalad finish` is similar to `datalad run`, and `datalad reschedule + datalad finish` is similar to `datalad rerun`.
+In the lingo of the original DataLad package, the combination of `datalad slurm-schedule + datalad slurm-finish` is similar to `datalad run`, and `datalad slurm-reschedule + datalad slurm-finish` is similar to `datalad rerun`.
 
 An example workflow could look like this (constructed deliberately to have some failed jobs):
 
-    datalad schedule -o models/abrupt/gold/ sbatch submit_gold.slurm
-    datalad schedule -o models/abrupt/silver/ sbatch submit_silver.slurm
-    datalad schedule -o models/abrupt/bronze/ sbatch submit_bronze.slurm
-    datalad schedule -o models/abrupt/platinum/ sbatch submit_array_platinum.slurm
+    datalad slurm-schedule -o models/abrupt/gold/ sbatch submit_gold.slurm
+    datalad slurm-schedule -o models/abrupt/silver/ sbatch submit_silver.slurm
+    datalad slurm-schedule -o models/abrupt/bronze/ sbatch submit_bronze.slurm
+    datalad slurm-schedule -o models/abrupt/platinum/ sbatch submit_array_platinum.slurm
 
 Checking the job statuses at some point while they are running:
 
-    datalad finish --list-open-jobs
+    datalad slurm-finish --list-open-jobs
     
     The following jobs are open: 
 
@@ -79,7 +79,7 @@ Checking the job statuses at some point while they are running:
 
 Later, once all the jobs have finished running:
 
-    datalad finish
+    datalad slurm-finish
     
     add(ok): models/abrupt/gold/05_02/slurm-10524442.out (file)                                                                                                                                                         
     add(ok): models/abrupt/gold/05_02/slurm-job-10524442.env.json (file)                                                                                                                                                
@@ -99,7 +99,7 @@ Later, once all the jobs have finished running:
 
 To close the failed jobs:
 
-    datalad finish --close-failed-jobs
+    datalad slurm-finish --close-failed-jobs
 
     finish(ok): [Closing failed / cancelled jobs. Statuses: 10524556: FAILED]
     finish(ok): [Closing failed / cancelled jobs. Statuses: 10524620_0: COMPLETED, 10524620_1: COMPLETED, 10524620_2: TIMEOUT]

--- a/datalad_slurm/__init__.py
+++ b/datalad_slurm/__init__.py
@@ -19,9 +19,9 @@ command_suite = (
             # name of the command class implementation in above module
             "Schedule",
             # optional name of the command in the cmdline API
-            "schedule",
+            "slurm-schedule",
             # optional name of the command in the Python API
-            "schedule",
+            "slurm_schedule",
         ),
         (
             # importable module that contains the schedule command implementation
@@ -29,9 +29,9 @@ command_suite = (
             # name of the command class implementation in above module
             "Finish",
             # optional name of the command in the cmdline API
-            "finish",
+            "slurm-finish",
             # optional name of the command in the Python API
-            "finish",
+            "slurm_finish",
         ),
         (
             # importable module that contains the schedule command implementation
@@ -39,9 +39,9 @@ command_suite = (
             # name of the command class implementation in above module
             "Reschedule",
             # optional name of the command in the cmdline API
-            "reschedule",
+            "slurm-reschedule",
             # optional name of the command in the Python API
-            "reschedule",
+            "slurm_reschedule",
         ),
     ],
 )

--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -105,7 +105,7 @@ class Finish(Interface):
     )
 
     @staticmethod
-    @datasetmethod(name="finish")
+    @datasetmethod(name="slurm-finish")
     @eval_results
     def __call__(
         slurm_job_id=None,
@@ -124,7 +124,7 @@ class Finish(Interface):
 
         if outputs and not slurm_job_id:
             yield get_status_dict(
-                "finish",
+                "slurm-finish",
                 ds=ds,
                 status="impossible",
                 message=(
@@ -140,7 +140,7 @@ class Finish(Interface):
             slurm_job_id_list, status_ok = get_scheduled_commits(ds)
             if not status_ok:
                 yield get_status_dict(
-                    "finish",
+                    "slurm-finish",
                     ds=ds,
                     status="error",
                     message=("Database connection cannot be established"),
@@ -232,7 +232,7 @@ def finish_cmd(
 
     if not explicit:
         yield get_status_dict(
-            "finish",
+            "slurm-finish",
             ds=ds,
             status="impossible",
             message=(
@@ -244,7 +244,7 @@ def finish_cmd(
 
     if not ds_repo.get_hexsha():
         yield get_status_dict(
-            "finish",
+            "slurm-finish",
             ds=ds,
             status="impossible",
             message="cannot rerun command, nothing recorded",
@@ -255,7 +255,7 @@ def finish_cmd(
     results = extract_from_db(ds, slurm_job_id)
     if not results:
         yield get_status_dict(
-            "finish",
+            "slurm-finish",
             status="error",
             message="Error accessing slurm job {} in database".format(slurm_job_id),
         )
@@ -269,7 +269,7 @@ def finish_cmd(
     # should throw an error if user doesn't specify outputs or directory
     if not outputs_to_save:
         err_msg = "You must specify which outputs to save from this slurm run."
-        yield get_status_dict("finish", status="impossible", message=err_msg)
+        yield get_status_dict("slurm-finish", status="impossible", message=err_msg)
         return
 
     slurm_job_id = slurm_run_info["slurm_job_id"]
@@ -291,17 +291,17 @@ def finish_cmd(
             f"Statuses: {status_summary}"
         )
         if any(status in ["PENDING", "RUNNING"] for status in job_states.values()):
-            yield get_status_dict("finish", status="impossible", message=message)
+            yield get_status_dict("slurm-finish", status="impossible", message=message)
             return
         else:
             if not close_failed_jobs:
-                yield get_status_dict("finish", status="impossible", message=message)
+                yield get_status_dict("slurm-finish", status="impossible", message=message)
                 return
             else:
                 # remove the job
                 remove_from_database(ds, slurm_run_info)
                 message = f"Closing failed / cancelled jobs. Statuses: {status_summary}"
-                yield get_status_dict("finish", status="ok", message=message)
+                yield get_status_dict("slurm-finish", status="ok", message=message)
                 return
 
     # expand the wildcards

--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -105,7 +105,7 @@ class Finish(Interface):
     )
 
     @staticmethod
-    @datasetmethod(name="slurm-finish")
+    @datasetmethod(name="slurm_finish")
     @eval_results
     def __call__(
         slurm_job_id=None,

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -167,7 +167,7 @@ class Reschedule(Interface):
     ]
 
     @staticmethod
-    @datasetmethod(name="reschedule")
+    @datasetmethod(name="slurm-reschedule")
     @eval_results
     def __call__(
         revision=None,
@@ -189,7 +189,7 @@ class Reschedule(Interface):
 
         if not ds_repo.get_hexsha():
             yield get_status_dict(
-                "reschedule",
+                "slurm-reschedule",
                 ds=ds,
                 status="impossible",
                 message="cannot reschedule command, nothing recorded",
@@ -273,7 +273,7 @@ def _revrange_as_results(dset, revrange):
         # custom `rev-list --parents ...` call to avoid this.)
         fields = rev_line.strip().split(" ")
         rev, parents = fields[0], fields[1:]
-        res = get_status_dict("reschedule", ds=dset, commit=rev, parents=parents)
+        res = get_status_dict("slurm-reschedule", ds=dset, commit=rev, parents=parents)
         full_msg = ds_repo.format_commit("%B", rev)
         try:
             msg, info = get_finish_info(dset, full_msg)
@@ -324,7 +324,7 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
     except ValueError as exc:
         ce = CapturedException(exc)
         yield get_status_dict(
-            "reschedule", status="error", message=str(ce), exception=ce
+            "slurm-reschedule", status="error", message=str(ce), exception=ce
         )
         return
 
@@ -336,7 +336,7 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch):
     results = list(dropwhile(lambda r: "slurm_run_info" not in r, results))
     if not results:
         yield get_status_dict(
-            "reschedule",
+            "slurm-reschedule",
             status="impossible",
             ds=dset,
             message=("No schedule commits found in range %s", revrange),
@@ -671,7 +671,7 @@ def _get_script_handler(script, since, revision):
             yield None
         else:
             yield get_status_dict(
-                "reschedule",
+                "slurm-reschedule",
                 ds=dset,
                 status="ok",
                 path=script,

--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -167,7 +167,7 @@ class Reschedule(Interface):
     ]
 
     @staticmethod
-    @datasetmethod(name="slurm-reschedule")
+    @datasetmethod(name="slurm_reschedule")
     @eval_results
     def __call__(
         revision=None,

--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -229,7 +229,7 @@ class Schedule(Interface):
     """
 
     @staticmethod
-    @datasetmethod(name="schedule")
+    @datasetmethod(name="slurm-schedule")
     @eval_results
     def __call__(
         cmd=None,
@@ -457,7 +457,7 @@ def schedule_cmd(
 
     if not outputs:
         yield get_status_dict(
-            "schedule",
+            "slurm-schedule",
             ds=ds,
             status="impossible",
             message=("At least one output must be specified for datalad schedule."),
@@ -474,7 +474,7 @@ def schedule_cmd(
         # MIH: is_dirty() is gone, but status() can do all of the above!
         if not explicit and ds.repo.dirty:
             yield get_status_dict(
-                "schedule",
+                "slurm-schedule",
                 ds=ds,
                 status="impossible",
                 message=(
@@ -487,7 +487,7 @@ def schedule_cmd(
     wildcard_list = ["*", "?", "[", "]", "!", "^", "{", "}"]
     if any(char in output for char in wildcard_list for output in outputs):
         yield get_status_dict(
-            "schedule",
+            "slurm-schedule",
             ds=ds,
             status="impossible",
             message=(
@@ -520,7 +520,7 @@ def schedule_cmd(
         )
         if not status_ok:
             yield get_status_dict(
-                "schedule",
+                "slurm-schedule",
                 ds=ds,
                 status="error",
                 message=("Database connection cannot be established"),
@@ -528,7 +528,7 @@ def schedule_cmd(
             return
         if output_conflict:
             yield get_status_dict(
-                "schedule",
+                "slurm-schedule",
                 ds=ds,
                 status="impossible",
                 message=(
@@ -557,7 +557,7 @@ def schedule_cmd(
         }
     except KeyError as exc:
         yield get_status_dict(
-            "schedule",
+            "slurm-schedule",
             ds=ds,
             status="impossible",
             message=(
@@ -600,7 +600,7 @@ def schedule_cmd(
         cmd_expanded = format_command(ds, cmd, **cmd_fmt_kwargs)
     except KeyError as exc:
         yield get_status_dict(
-            "schedule",
+            "slurm-schedule",
             ds=ds,
             status="impossible",
             message=("command has an unrecognized placeholder: %s", exc),
@@ -702,7 +702,7 @@ def schedule_cmd(
     )
     if not status_ok:
         yield get_status_dict(
-            "schedule",
+            "slurm-schedule",
             ds=ds,
             status="error",
             message=("Database connection cannot be established"),
@@ -710,7 +710,7 @@ def schedule_cmd(
         return
 
     run_result = get_status_dict(
-        "schedule",
+        "slurm-schedule",
         ds=ds,
         status=status,
         # use the abbrev. command as the message to give immediate clarity what

--- a/datalad_slurm/schedule.py
+++ b/datalad_slurm/schedule.py
@@ -229,7 +229,7 @@ class Schedule(Interface):
     """
 
     @staticmethod
-    @datasetmethod(name="slurm-schedule")
+    @datasetmethod(name="slurm_schedule")
     @eval_results
     def __call__(
         cmd=None,

--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -4,6 +4,6 @@ Command line reference
 .. toctree::
    :maxdepth: 1
 
-   generated/man/datalad-schedule
-   generated/man/datalad-finish
-   generated/man/datalad-reschedule
+   generated/man/datalad-slurm-schedule
+   generated/man/datalad-slurm-finish
+   generated/man/datalad-slurm-reschedule

--- a/docs/source/python_reference.rst
+++ b/docs/source/python_reference.rst
@@ -5,6 +5,6 @@ High-level API commands
 .. autosummary::
    :toctree: generated
 
-   schedule
-   finish
-   reschedule
+   slurm_schedule
+   slurm_finish
+   slurm_reschedule

--- a/tests/test_01_many_jobs.sh
+++ b/tests/test_01_many_jobs.sh
@@ -2,10 +2,10 @@
 
 set -e # abort on errors
 
-# Test datalad 'schedule' and 'finish' functionality
+# Test datalad 'slurm-schedule' and 'slurm-finish' functionality
 #   - create some job dirs and job scripts and 'commit' them
-#   - then 'datalad schedule' all jobs from their job dirs
-#   - wait until all of them are finished, then run 'datalad finish'
+#   - then 'datalad slurm-schedule' all jobs from their job dirs
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #
 # Expected results: should run without any errors
 
@@ -90,7 +90,7 @@ for i in $TARGETS ; do
     DIR="test_01_output_dir_"$i
 
     cd $DIR
-    datalad schedule -o $PWD sbatch slurm.sh
+    datalad slurm-schedule -o $PWD sbatch slurm.sh
     cd ..
 
 done
@@ -101,10 +101,10 @@ while [[ 0 != `squeue -u $USER | grep "DLtest01" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 echo "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
 #echo " ### git log in this repo ### "
 #echo ""

--- a/tests/test_02_conflicting_jobs.sh
+++ b/tests/test_02_conflicting_jobs.sh
@@ -2,11 +2,11 @@
 
 set +e # do NOT abort on errors
 
-# Test datalad 'schedule' and 'finish' functionality
+# Test datalad 'slurm-schedule' and 'slurm-finish' functionality
 #   - create some job dirs and job scripts and 'commit' them
-#   - then 'datalad schedule' all jobs from their job dirs
-#   - then 'datalad schedule' more jobs from the same set of job dirs
-#   - wait until all of them are finished, then run 'datalad finish'
+#   - then 'datalad slurm-schedule' all jobs from their job dirs
+#   - then 'datalad slurm-schedule' more jobs from the same set of job dirs
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #
 # Expected results: should handle the first set of jobs fine until the end, 
 # but refuse to schedule the second set of jobs
@@ -94,7 +94,7 @@ for i in $TARGETS ; do
     DIR="test_02_output_dir_"$i
 
     cd $DIR
-    datalad schedule -o $PWD sbatch slurm1.sh
+    datalad slurm-schedule -o $PWD sbatch slurm1.sh
     cd ..
 
 done
@@ -108,7 +108,7 @@ for i in $TARGETS ; do
     DIR="test_02_output_dir_"$i
 
     cd $DIR
-    datalad schedule -o $PWD sbatch slurm2.sh
+    datalad slurm-schedule -o $PWD sbatch slurm2.sh
     cd ..
 
 done
@@ -120,13 +120,13 @@ while [[ 0 != `squeue -u $USER | grep "DLtest02" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 echo "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
 echo "closing failed jobs:"
-datalad finish --close-failed-jobs
+datalad slurm-finish --close-failed-jobs
 
 #echo " ### git log in this repo ### "
 #echo ""

--- a/tests/test_03_output_to_same_dir.sh
+++ b/tests/test_03_output_to_same_dir.sh
@@ -2,9 +2,9 @@
 
 set -e # abort on errors
 
-# Test datalad 'schedule' and 'finish' functionality
-#   - 'datalad schedule' several jobs with the same output dir but different output file names
-#   - wait until all of them are finished, then run 'datalad finish'
+# Test datalad 'slurm-schedule' and 'slurm-finish' functionality
+#   - 'datalad slurm-schedule' several jobs with the same output dir but different output file names
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #
 # Expected results: should run without any errors
 
@@ -92,7 +92,7 @@ for i in $TARGETS ; do
 
     OUTPUTFILENAME="test_03_output_file_"$i
 
-    datalad schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
+    datalad slurm-schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
 
 done
 
@@ -104,10 +104,10 @@ while [[ 0 != `squeue -u $USER | grep "DLtest03" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 echo "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
 #echo " ### git log in this repo ### "
 #echo ""

--- a/tests/test_04_conflicting_in_same_dir.sh
+++ b/tests/test_04_conflicting_in_same_dir.sh
@@ -2,10 +2,10 @@
 
 set +e # continue on errors
 
-# Test datalad 'schedule' and 'finish' functionality
-#   - 'datalad schedule' several jobs with the same output dir but different output file names
-#   - then 'datalad schedule' more jobs from the same set of job dirs
-#   - wait until all of them are finished, then run 'datalad finish'
+# Test datalad 'slurm-schedule' and 'slurm-finish' functionality
+#   - 'datalad slurm-schedule' several jobs with the same output dir but different output file names
+#   - then 'datalad slurm-schedule' more jobs from the same set of job dirs
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #
 # Expected results: should handle the first set of jobs fine until the end, 
 # but refuse to schedule the second set of jobs
@@ -94,8 +94,8 @@ for i in $TARGETS ; do
 
     OUTPUTFILENAME="test_04_output_file_"$i
 
-    echo datalad schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
-    datalad schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
+    echo datalad slurm-schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
+    datalad slurm-schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
 
 done
 
@@ -111,8 +111,8 @@ for i in $TARGETS ; do
 
     OUTPUTFILENAME="test_04_output_file_"$i
 
-    echo datalad schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
-    datalad schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
+    echo datalad slurm-schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
+    datalad slurm-schedule -o $PWD/$OUTPUTFILENAME sbatch slurm.sh $OUTPUTFILENAME
 
 done
 
@@ -125,13 +125,13 @@ while [[ 0 != `squeue -u $USER | grep "DLtest04" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 echo "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
 echo "closing failed jobs:"
-datalad finish --close-failed-jobs
+datalad slurm-finish --close-failed-jobs
 
 #echo " ### git log in this repo ### "
 #echo ""

--- a/tests/test_05_failed_jobs.sh
+++ b/tests/test_05_failed_jobs.sh
@@ -2,11 +2,11 @@
 
 set +e # continue on errors
 
-# Test how datalad 'schedule' and 'finish' handle failed jobs
+# Test how datalad 'slurm-schedule' and 'slurm-finish' handle failed jobs
 #   - create some job dirs and job scripts and 'commit' them
-#   - then 'datalad schedule' all jobs from their job dirs
+#   - then 'datalad slurm-schedule' all jobs from their job dirs
 #   - some of the jobs will fail (also feel free to `scancel some`)
-#   - wait until all of them are finished, then run 'datalad finish'
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #   - check if the remaining jobs will be shown correctly
 #   - check if the remaining jobs are correctly closed
 #
@@ -96,7 +96,7 @@ for i in $TARGETS ; do
     DIR="test_05_output_dir_"$i
 
     cd $DIR
-    datalad schedule -o $PWD sbatch slurm.sh $i
+    datalad slurm-schedule -o $PWD sbatch slurm.sh $i
     cd ..
 
 done
@@ -107,19 +107,19 @@ while [[ 0 != `squeue -u $USER | grep "DLtest05" | wc -l` ]] ; do
     sleep 1m
 done
 
-echo -e "\n #### Open jobs before 'datalad finish':\n"
-datalad finish --list-open-jobs
+echo -e "\n #### Open jobs before 'datalad slurm-finish':\n"
+datalad slurm-finish --list-open-jobs
 
 echo -e "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
-echo -e \n" #### Open jobs after 'datalad finish':\n"
-datalad finish --list-open-jobs
+echo -e \n" #### Open jobs after 'datalad slurm-finish':\n"
+datalad slurm-finish --list-open-jobs
 
 echo "closing failed jobs :"
-datalad finish --close-failed-jobs
+datalad slurm-finish --close-failed-jobs
 
-echo -e "\n #### Open jobs after 'datalad finish --close-failed-jobs':\n"
-datalad finish --list-open-jobs
+echo -e "\n #### Open jobs after 'datalad slurm-finish --close-failed-jobs':\n"
+datalad slurm-finish --list-open-jobs
 
 

--- a/tests/test_06_array_jobs.sh
+++ b/tests/test_06_array_jobs.sh
@@ -2,11 +2,11 @@
 
 set -e # abort on errors
 
-# Test how datalad 'schedule' and 'finish' handle failed jobs
+# Test how datalad 'slurm-schedule' and 'slurm-finish' handle failed jobs
 #   - create some job dirs and job scripts and 'commit' them
-#   - then 'datalad schedule' all jobs from their job dirs
+#   - then 'datalad slurm-schedule' all jobs from their job dirs
 #   - some of the jobs will fail (also feel free to `scancel some`)
-#   - wait until all of them are finished, then run 'datalad finish'
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #   - check if the remaining jobs will be shown correctly
 #   - check if the remaining jobs are correctly closed
 #
@@ -90,8 +90,8 @@ for i in $TARGETS ; do
     DIR="test_06_output_dir_"$i
 
     cd $DIR
-    echo datalad schedule -o $PWD sbatch slurm.sh
-    datalad schedule -o $PWD sbatch slurm.sh
+    echo datalad slurm-schedule -o $PWD sbatch slurm.sh
+    datalad slurm-schedule -o $PWD sbatch slurm.sh
     cd ..
 
 done
@@ -102,12 +102,12 @@ while [[ 0 != `squeue -u $USER | grep "DLtest06" | wc -l` ]] ; do
     sleep 1m
 done
 
-echo -e "\n #### Open jobs before 'datalad finish':\n"
-datalad finish --list-open-jobs
+echo -e "\n #### Open jobs before 'datalad slurm-finish':\n"
+datalad slurm-finish --list-open-jobs
 
 echo -e "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
-echo -e \n" #### Open jobs after 'datalad finish':\n"
-datalad finish --list-open-jobs
+echo -e \n" #### Open jobs after 'datalad slurm-finish':\n"
+datalad slurm-finish --list-open-jobs
 

--- a/tests/test_07_multiple_conflicting_dirs.sh
+++ b/tests/test_07_multiple_conflicting_dirs.sh
@@ -2,10 +2,10 @@
 
 set +e # do NOT abort on errors
 
-# Test datalad 'schedule' and 'finish' functionality
-#   - 'datalad schedule' several jobs with the same output dir but different output file names
-#   - then 'datalad schedule' more jobs from the same set of job dirs
-#   - wait until all of them are finished, then run 'datalad finish'
+# Test datalad 'slurm-schedule' and 'slurm-finish' functionality
+#   - 'datalad slurm-schedule' several jobs with the same output dir but different output file names
+#   - then 'datalad slurm-schedule' more jobs from the same set of job dirs
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
 #
 # Expected results: should handle the first set of jobs fine until the end, 
 # but refuse to schedule the second set of jobs
@@ -81,7 +81,7 @@ chmod u+x $TESTDIR/slurm.template.sh
 cd $TESTDIR
 MAINDIR=$PWD
 
-DIR="test_04_output_dir_for_all"
+DIR="test_07_output_dir_for_all"
 mkdir -p $DIR
 
 # First we schedule jobs which don't conflict
@@ -101,8 +101,8 @@ for SUBDIR in "${SUBDIRS1[@]}"; do
 
     OUTPUTFILENAME="test_07_output_file"
 
-    echo datalad schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
-    datalad schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
+    echo datalad slurm-schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
+    datalad slurm-schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
 
 done
 
@@ -122,8 +122,8 @@ for SUBDIR in "${SUBDIRS2[@]}"; do
 
     OUTPUTFILENAME="test_07_output_file"
 
-    echo datalad schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
-    datalad schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
+    echo datalad slurm-schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
+    datalad slurm-schedule -o $PWD sbatch slurm.sh $OUTPUTFILENAME
 
     cd $SUBDIR
 
@@ -137,13 +137,13 @@ while [[ 0 != `squeue -u $USER | grep "DLtest07" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 echo "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
 echo "closing failed jobs:"
-datalad finish --close-failed-jobs
+datalad slurm-finish --close-failed-jobs
 
 #echo " ### git log in this repo ### "
 #echo ""

--- a/tests/test_08_timings.sh
+++ b/tests/test_08_timings.sh
@@ -2,7 +2,7 @@
 
 set +e # continue on errors
 
-# Test datalad 'schedule' and 'finish --list-open-jobs' and 'finish' functionality
+# Test datalad 'slurm-schedule' and 'slurm-finish --list-open-jobs' and 'slurm-finish' functionality
 #   - measure how long they take with growing git log length
 #
 # Expected results: should run without any errors
@@ -69,7 +69,7 @@ chmod u+x $TESTDIR/slurm.template.sh
 
 cd $TESTDIR
 
-TARGETS=`seq 1 100`
+TARGETS=`seq 1 10`
 
 echo "Create job scripts:"
 
@@ -93,13 +93,13 @@ for i in $TARGETS ; do
 
 
     echo -n $i" ">>timing_schedule.txt
-    /usr/bin/time -f "%e" -o timing_schedule.txt -a datalad schedule -o $DIR sbatch --chdir $DIR slurm.sh
+    /usr/bin/time -f "%e" -o timing_schedule.txt -a datalad slurm-schedule -o $DIR sbatch --chdir $DIR slurm.sh
 
     sleep 0.1s
 
     ## TODO the follwoing line produces a error sometimes: "[ERROR  ] Job 9889098 not found"
     echo -n $i" ">>timing_finish-list.txt
-    /usr/bin/time -f "%e" -o timing_finish-list.txt -a datalad finish --list-open-jobs
+    /usr/bin/time -f "%e" -o timing_finish-list.txt -a datalad slurm-finish --list-open-jobs
 
 done
 
@@ -112,7 +112,7 @@ done
 echo "done waiting"
 
 echo "finishing completed jobs:"
-/usr/bin/time -f "%e" -o timing_finish.txt -a datalad finish
+/usr/bin/time -f "%e" -o timing_finish.txt -a datalad slurm-finish
 
 #echo " ### git log in this repo ### "
 #echo ""

--- a/tests/test_09_reschedule.sh
+++ b/tests/test_09_reschedule.sh
@@ -2,14 +2,14 @@
 
 set +e # continue on errors
 
-# Test datalad 'reschedule' 
+# Test datalad 'slurm-reschedule' 
 #   - create some job dirs and job scripts and 'commit' them
-#   - then 'datalad schedule' all jobs from their job dirs
-#   - wait until all of them are finished, then run 'datalad reschedule --since='
-#   - then run 'datalad reschedule --since=' again
-#   - wait until all reschedule jobs are finished and then run 'datalad finish'
+#   - then 'datalad slurm-schedule' all jobs from their job dirs
+#   - wait until all of them are finished, then run 'datalad slurm-reschedule --since='
+#   - then run 'datalad slurm-reschedule --since=' again
+#   - wait until all reschedule jobs are finished and then run 'datalad slurm-finish'
 #
-# Expected results: The first 'datalad reschedule' should run without errors;
+# Expected results: The first 'datalad slurm-reschedule' should run without errors;
 # the second should produce an error because of output conflicts
 
 if [[ -z $1 ]] ; then
@@ -93,7 +93,7 @@ for i in $TARGETS ; do
     DIR="test_09_output_dir_"$i
 
     cd $DIR
-    datalad schedule -o $PWD sbatch slurm.sh
+    datalad slurm-schedule -o $PWD sbatch slurm.sh
     cd ..
 
 done
@@ -104,18 +104,18 @@ while [[ 0 != `squeue -u $USER | grep "DLtest09" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 echo "finishing completed jobs:"
-datalad finish
+datalad slurm-finish
 
 # now we reschedule the jobs (should work without issues)
 echo "rescheduling all jobs:"
-datalad reschedule --since=
+datalad slurm-reschedule --since=
 
 # now reschedule again - should fail due to conflicts
 echo "rescheduling jobs with conflicts (should fail):"
-datalad reschedule --since=
+datalad slurm-reschedule --since=
 
 while [[ 0 != `squeue -u $USER | grep "DLtest09" | wc -l` ]] ; do
 
@@ -123,11 +123,11 @@ while [[ 0 != `squeue -u $USER | grep "DLtest09" | wc -l` ]] ; do
     sleep 1m
 done
 
-datalad finish --list-open-jobs
+datalad slurm-finish --list-open-jobs
 
 # close up rescheduled jobs
 echo "finishing rescheduled jobs"
-datalad finish --close-failed-jobs
+datalad slurm-finish --close-failed-jobs
 
 
 #echo " ### git log in this repo ### "


### PR DESCRIPTION
Fix for issue #71. The commands are now renamed like:

`datalad slurm-schedule`
`datalad slurm-finish`
`datalad slurm-reschedule`

to distinguish them from the main datalad namespace